### PR TITLE
Fix clear functionality

### DIFF
--- a/lib/daterange-picker.js
+++ b/lib/daterange-picker.js
@@ -605,6 +605,7 @@ class DaterangePicker {
 		}
 		
 		if (
+			date1 != false &&
 			// Date1 too early?
 			(opt.startDate && calendar.compareDay(date1, opt.startDate) < 0) ||
 			// Date2 too late?


### PR DESCRIPTION
When clearing the date range, setDateRange is called with date1 and date2 set to false. The check if date1 is too early prevents the date range picker from being reset. We can fix this problem if we add a check if date1 is not false.