### PR TITLE
Do not trigger events on clearSelection

### DIFF
--- a/lib/daterange-picker.js
+++ b/lib/daterange-picker.js
@@ -342,7 +342,7 @@ class DaterangePicker {
 		this.setDateRange(this.getDateRange().start, false, false, true);
 	}
 	clearSelection() {
-		this.setDateRange(false, false, false, true);
+		this.setDateRange(false, false, true, true);
 	}
 
 	/*


### PR DESCRIPTION
When using clearSelection, the dateRange should be reset silently (we do not want to trigger validation)