### PR TITLE
Always update month positions when opening date picker

### DIFF
--- a/lib/plugins/jquery-plugin.js
+++ b/lib/plugins/jquery-plugin.js
@@ -116,9 +116,9 @@ class JqueryDaterangePicker {
 				const m2 = moment(dates[1], fmt, loc);
 				if (m1.isValid() && m2.isValid()) {
 					if (opt.singleDate) {
-						this.picker.setSingleDate(m1.toDate(), false, true);
+						this.picker.setSingleDate(m1.toDate(), false, false);
 					} else {
-						this.picker.setDateRange(m1.toDate(), m2.toDate(), false, true);
+						this.picker.setDateRange(m1.toDate(), m2.toDate(), false, false);
 					}
 				} else {
 					console.warn('One of the dates to be set on the picker is illegal: ' + dates[0] + ' - ' + dates[1]);
@@ -126,9 +126,9 @@ class JqueryDaterangePicker {
 			} else { // date.length === 1
 				if (m1.isValid()) {
 					if (opt.singleDate) {
-						this.picker.setSingleDate(m1.toDate(), true);
+						this.picker.setSingleDate(m1.toDate(), true, false);
 					} else {
-						this.picker.setDateRange(m1.toDate(), false, true, true);
+						this.picker.setDateRange(m1.toDate(), false, true, false);
 					}
 				} else {
 					console.warn('The date to be set on the picker is illegal: ' + dates[0]);


### PR DESCRIPTION
When opening the date range picker, the visible months should correspond to the currently selected start and end date (whether it was chosen via the picker itself or entered manually in the input field).